### PR TITLE
feat(SideCarPlugin): implement sidecar plugin interface

### DIFF
--- a/pkg/plugins/common/logger.go
+++ b/pkg/plugins/common/logger.go
@@ -1,4 +1,4 @@
-package driver
+package common
 
 import (
 	"io"

--- a/pkg/plugins/common/logger_test.go
+++ b/pkg/plugins/common/logger_test.go
@@ -1,4 +1,4 @@
-package driver
+package common
 
 import (
 	"testing"

--- a/pkg/plugins/driver/server.go
+++ b/pkg/plugins/driver/server.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/stroppy-io/stroppy-core/pkg/logger"
+	"github.com/stroppy-io/stroppy-core/pkg/plugins/common"
 	stroppy "github.com/stroppy-io/stroppy-core/pkg/proto"
 	"github.com/stroppy-io/stroppy-core/pkg/utils/errchan"
 )
@@ -92,6 +93,6 @@ func ServePlugin(impl Plugin) {
 		},
 		// A non-nil value here enables gRPC serving for this plugin...
 		GRPCServer: plugin.DefaultGRPCServer,
-		Logger:     NewLogger(logger.NewFromEnv()),
+		Logger:     common.NewLogger(logger.NewFromEnv()),
 	})
 }

--- a/pkg/plugins/sidecar/server.go
+++ b/pkg/plugins/sidecar/server.go
@@ -1,0 +1,68 @@
+package driver
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-plugin"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/stroppy-io/stroppy-core/pkg/logger"
+	"github.com/stroppy-io/stroppy-core/pkg/plugins/common"
+	stroppy "github.com/stroppy-io/stroppy-core/pkg/proto"
+)
+
+type server struct {
+	impl Plugin
+	*stroppy.UnimplementedSidecarPluginServer
+}
+
+func newDriverServer(impl Plugin) *server {
+	return &server{
+		impl:                             impl,
+		UnimplementedSidecarPluginServer: &stroppy.UnimplementedSidecarPluginServer{},
+	}
+}
+
+func (s server) Initialize(
+	ctx context.Context,
+	context *stroppy.StepContext,
+) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, s.impl.Initialize(ctx, context)
+}
+
+func (s server) OnStepStart(
+	ctx context.Context,
+	event *stroppy.StepContext,
+) (*emptypb.Empty, error) {
+	err := s.impl.OnStepStart(ctx, event)
+
+	return &emptypb.Empty{}, err
+}
+
+func (s server) OnStepEnd(
+	ctx context.Context,
+	event *stroppy.StepContext,
+) (*emptypb.Empty, error) {
+	err := s.impl.OnStepEnd(ctx, event)
+
+	return &emptypb.Empty{}, err
+}
+
+func (s server) Teardown(
+	ctx context.Context,
+	_ *emptypb.Empty,
+) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, s.impl.Teardown(ctx)
+}
+
+func ServePlugin(impl Plugin) {
+	plugin.Serve(&plugin.ServeConfig{
+		HandshakeConfig: PluginHandshake,
+		Plugins: map[string]plugin.Plugin{
+			PluginName: NewSharedPlugin(impl),
+		},
+		// A non-nil value here enables gRPC serving for this plugin...
+		GRPCServer: plugin.DefaultGRPCServer,
+		Logger:     common.NewLogger(logger.NewFromEnv()),
+	})
+}

--- a/pkg/plugins/sidecar/shared.go
+++ b/pkg/plugins/sidecar/shared.go
@@ -1,0 +1,56 @@
+package driver
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-plugin"
+	"google.golang.org/grpc"
+
+	stroppy "github.com/stroppy-io/stroppy-core/pkg/proto"
+)
+
+const (
+	pluginVersion    = 1
+	magicCookieKey   = "stroppy_SIDECAR_PLUGIN"
+	magicCookieValue = "stroppy_SIDECAR_PLUGIN_HANDSHAKE"
+	PluginName       = "sidecar_grpc"
+)
+
+var PluginHandshake = plugin.HandshakeConfig{ //nolint: gochecknoglobals // allow in shared
+	// This isn't required when using VersionedPlugins
+	ProtocolVersion:  pluginVersion,
+	MagicCookieKey:   magicCookieKey,
+	MagicCookieValue: magicCookieValue,
+}
+
+type Plugin interface {
+	Initialize(ctx context.Context, runContext *stroppy.StepContext) error
+	OnStepStart(ctx context.Context, event *stroppy.StepContext) error
+	OnStepEnd(ctx context.Context, event *stroppy.StepContext) error
+	Teardown(ctx context.Context) error
+}
+type SharedPlugin struct {
+	plugin.Plugin
+	Impl Plugin
+}
+
+func NewSharedPlugin(impl Plugin) *SharedPlugin {
+	return &SharedPlugin{Impl: impl}
+}
+
+func (s SharedPlugin) GRPCServer(
+	_ *plugin.GRPCBroker,
+	g *grpc.Server,
+) error {
+	stroppy.RegisterSidecarPluginServer(g, newDriverServer(s.Impl))
+
+	return nil
+}
+
+func (s SharedPlugin) GRPCClient(
+	_ context.Context,
+	_ *plugin.GRPCBroker,
+	conn *grpc.ClientConn,
+) (interface{}, error) {
+	return newDriverClient(stroppy.NewSidecarPluginClient(conn)), nil
+}


### PR DESCRIPTION
Implement SideCarPlugin from protocols using go-plugin.

Task: RNDPOSTGRES-58

# Pull Request

## Description of Changes
Briefly describe the changes introduced.

Now it does not support transaction streaming paradigm

## Motivation and Context
Why is this change required?

Allow users to write their own plugins outside Stroppy with event notifications.

## Type of Changes
- [ ] Bug fix
- [x] New feature
- [ ] Documentation improvement
- [ ] Refactoring
- [ ] Other

## Checklist
- [x] I have read the CONTRIBUTING.md
- [x] I have checked build and tests
- [x] I have updated documentation if needed 